### PR TITLE
Add Kubernetes auth endpoint param

### DIFF
--- a/config/crds/v1/databases.schemahero.io_databases.yaml
+++ b/config/crds/v1/databases.schemahero.io_databases.yaml
@@ -120,6 +120,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -209,6 +211,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -297,6 +301,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -393,6 +399,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -481,6 +489,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -571,6 +581,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -659,6 +671,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -749,6 +763,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -838,6 +854,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -926,6 +944,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -1021,6 +1041,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -1114,6 +1136,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -1202,6 +1226,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -1292,6 +1318,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -1381,6 +1409,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -1469,6 +1499,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -1562,6 +1594,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -1650,6 +1684,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -1740,6 +1776,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -1828,6 +1866,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -1918,6 +1958,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -2007,6 +2049,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -2095,6 +2139,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string

--- a/config/crds/v1beta1/databases.schemahero.io_databases.yaml
+++ b/config/crds/v1beta1/databases.schemahero.io_databases.yaml
@@ -120,6 +120,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -209,6 +211,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -297,6 +301,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -393,6 +399,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -481,6 +489,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -571,6 +581,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -659,6 +671,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -749,6 +763,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -838,6 +854,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -926,6 +944,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1021,6 +1041,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1114,6 +1136,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1202,6 +1226,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1292,6 +1318,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1381,6 +1409,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1469,6 +1499,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1562,6 +1594,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1650,6 +1684,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1740,6 +1776,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1828,6 +1866,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1918,6 +1958,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -2007,6 +2049,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -2095,6 +2139,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string

--- a/pkg/apis/databases/v1alpha4/string_or_value.go
+++ b/pkg/apis/databases/v1alpha4/string_or_value.go
@@ -28,6 +28,7 @@ type Vault struct {
 	ServiceAccount          string `json:"serviceAccount,omitempty" yaml:"serviceAccount,omitempty"`
 	ServiceAccountNamespace string `json:"serviceAccountNamespace,omitempty" yaml:"serviceAccountNamespace,omitempty"`
 	ConnectionTemplate      string `json:"connectionTemplate,omitempty" yaml:"connectionTemplate,omitempty"`
+	KubernetesAuthEndpoint  string `json:"kubernetesAuthEndpoint,omitempty" yaml:"kubernetesAuthEndpoint,omitempty"`
 }
 
 type SSM struct {

--- a/pkg/apis/databases/v1alpha4/vault.go
+++ b/pkg/apis/databases/v1alpha4/vault.go
@@ -107,6 +107,11 @@ func (d *Database) GetVaultAnnotations() (map[string]string, error) {
 			template = fmt.Sprintf(`
 {{- with secret "database/creds/%s" -}}
 postgres://{{ .Data.username }}:{{ .Data.password }}@postgres:5432/%s{{- end }}`, v.Role, d.Name)
+		} else {
+			t = fmt.Sprintf(`
+{{- with secret "database/creds/%s" -}}
+%s`, v.Role, connTemplate)
+		}
 
 		case "mysql":
 			template = fmt.Sprintf(`

--- a/pkg/apis/databases/v1alpha4/vault_connection.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection.go
@@ -74,7 +74,11 @@ func (d *Database) getVaultConnection(ctx context.Context, clientset kubernetes.
 		return "", "", errors.Wrap(err, "failed to marshal login payload")
 	}
 
-	req, err := http.NewRequest("POST", fmt.Sprintf("%s/v1/auth/kubernetes/login", valueOrValueFrom.ValueFrom.Vault.Endpoint), bytes.NewReader(marshalledLoginBody))
+	k8sAuthEndpoint := "/v1/auth/kubernetes/login"
+	if valueOrValueFrom.ValueFrom.Vault.KubernetesAuthEndpoint != "" {
+		k8sAuthEndpoint = valueOrValueFrom.ValueFrom.Vault.KubernetesAuthEndpoint
+	}
+	req, err := http.NewRequest("POST", fmt.Sprintf("%s%s", valueOrValueFrom.ValueFrom.Vault.Endpoint, k8sAuthEndpoint), bytes.NewReader(marshalledLoginBody))
 	if err != nil {
 		return "", "", errors.Wrap(err, "failed to create login request")
 	}

--- a/pkg/apis/databases/v1alpha4/vault_connection_test.go
+++ b/pkg/apis/databases/v1alpha4/vault_connection_test.go
@@ -51,8 +51,7 @@ func TestGetConnectionURIFromTemplate(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
-			d := &Database{}
-			s := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
 				case "/v1/auth/kubernetes/login":
 					rw.Write([]byte(`{
@@ -73,10 +72,11 @@ func TestGetConnectionURIFromTemplate(t *testing.T) {
 					rw.Write([]byte(fmt.Sprintf("Unknown path: %s", r.URL.Path)))
 				}
 			}))
-			defer s.Close()
+			defer srv.Close()
 
-			test.valueOrValueFrom.ValueFrom.Vault.Endpoint = s.URL
+			test.valueOrValueFrom.ValueFrom.Vault.Endpoint = srv.URL
 
+			d := &Database{}
 			_, uri, err := d.getVaultConnection(context.TODO(), fake.NewSimpleClientset(sa, sc), test.driver, test.valueOrValueFrom)
 			assert.NoError(t, err)
 
@@ -165,6 +165,90 @@ func TestGetConnectionURIFromVault(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.Equal(t, fmt.Sprintf("postgresql://%s:%s@postgresql:5432/schema", test.tmpUser, test.tmpPassword), uri)
+		})
+	}
+}
+
+func TestKubernetesAuthEndpoint(t *testing.T) {
+	tests := []struct {
+		name                     string
+		kubernetesAuthEndpoint   string
+		expectedKubeAuthEndpoint string
+		valueOrValueFrom         ValueOrValueFrom
+	}{
+		{
+			name:                     "uses_default_endpoint",
+			expectedKubeAuthEndpoint: "/v1/auth/kubernetes/login",
+			valueOrValueFrom: ValueOrValueFrom{
+				ValueFrom: &ValueFrom{
+					Vault: &Vault{
+						ConnectionTemplate: "postgresql://{{ .username }}:{{ .password }}@postgresql:5432/schema",
+						Secret:             "secret",
+					},
+				},
+			},
+		},
+		{
+			name:                     "uses_specified_endpoint",
+			expectedKubeAuthEndpoint: "/v1/auth/kubernetes_custom/login",
+			valueOrValueFrom: ValueOrValueFrom{
+				ValueFrom: &ValueFrom{
+					Vault: &Vault{
+						ConnectionTemplate:     "postgresql://{{ .username }}:{{ .password }}@postgresql:5432/schema",
+						Secret:                 "secret",
+						KubernetesAuthEndpoint: "/v1/auth/kubernetes_custom/login",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			endpointReached := false
+			var actualEndpoint string
+			srv := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+				switch path := r.URL.Path; {
+				case path == test.expectedKubeAuthEndpoint:
+					endpointReached = true
+					rw.Write([]byte(`{
+  "auth": {
+    "client_token": "blah"
+  }
+}`))
+				case path == "/v1/database/creds/secret":
+					rw.Write([]byte(`{
+  "lease_duration": 86400,
+  "data": {
+    "username": "someuser",
+    "password": "p@ssw0rd"
+  }
+}`))
+				default:
+					actualEndpoint = path
+				}
+			}))
+
+			test.valueOrValueFrom.ValueFrom.Vault.Endpoint = srv.URL
+
+			d := &Database{}
+			sc := &v1.Secret{}
+			sa := &v1.ServiceAccount{
+				Secrets: []v1.ObjectReference{
+					{
+						Namespace: "",
+					},
+				},
+			}
+
+			_, _, err := d.getVaultConnection(context.TODO(), fake.NewSimpleClientset(sa, sc), "postgresql", test.valueOrValueFrom)
+
+			assert.NoError(t, err)
+			assert.True(t, endpointReached, "Expected endpoint %s to be hit, but instead we called %s", test.expectedKubeAuthEndpoint, actualEndpoint)
 		})
 	}
 }

--- a/pkg/installer/database_objects.go
+++ b/pkg/installer/database_objects.go
@@ -122,6 +122,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -211,6 +213,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -299,6 +303,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -395,6 +401,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -483,6 +491,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -573,6 +583,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -661,6 +673,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -751,6 +765,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -840,6 +856,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -928,6 +946,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1023,6 +1043,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1116,6 +1138,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1204,6 +1228,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1294,6 +1320,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1383,6 +1411,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1471,6 +1501,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1564,6 +1596,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1652,6 +1686,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1742,6 +1778,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -1830,6 +1868,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -1920,6 +1960,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -2009,6 +2051,8 @@ spec:
                                   type: string
                                 endpoint:
                                   type: string
+                                kubernetesAuthEndpoint:
+                                  type: string
                                 role:
                                   type: string
                                 secret:
@@ -2097,6 +2141,8 @@ spec:
                                 connectionTemplate:
                                   type: string
                                 endpoint:
+                                  type: string
+                                kubernetesAuthEndpoint:
                                   type: string
                                 role:
                                   type: string
@@ -2283,6 +2329,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -2372,6 +2420,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -2460,6 +2510,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -2556,6 +2608,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -2644,6 +2698,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -2734,6 +2790,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -2822,6 +2880,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -2912,6 +2972,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -3001,6 +3063,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -3089,6 +3153,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -3184,6 +3250,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -3277,6 +3345,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -3365,6 +3435,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -3455,6 +3527,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -3544,6 +3618,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -3632,6 +3708,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -3725,6 +3803,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -3813,6 +3893,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -3903,6 +3985,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -3991,6 +4075,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string
@@ -4081,6 +4167,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -4170,6 +4258,8 @@ spec:
                                     type: string
                                   endpoint:
                                     type: string
+                                  kubernetesAuthEndpoint:
+                                    type: string
                                   role:
                                     type: string
                                   secret:
@@ -4258,6 +4348,8 @@ spec:
                                   connectionTemplate:
                                     type: string
                                   endpoint:
+                                    type: string
+                                  kubernetesAuthEndpoint:
                                     type: string
                                   role:
                                     type: string


### PR DESCRIPTION
This allows for situations where the Vault Kubernetes authentication was
not enabled on the default path (auth/kubernetes/login). See
https://www.vaultproject.io/docs/auth/kubernetes#authentication for more
info.

Signed-off-by: Paul Thomson <thomsonp83@gmail.com>